### PR TITLE
Declare apex site name to disambiguate subdomains in Google

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,42 @@ Free for personal and commercial use under the CCA 3.0 license (html5up.net/lice
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="msapplication-config" content="/favicons/browserconfig.xml">
     <meta name="theme-color" content="#ffffff">
+    <meta name="application-name" content="Paul Lisker">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Paul Lisker">
+    <meta property="og:title" content="Paul Lisker | Software Engineer & Privacy Researcher">
+    <meta property="og:description"
+        content="Paul Lisker is a Chicago-based software engineer. A Harvard alumnus, he is a passionate bird photographer and is often found playing guitar or solving crosswords.">
+    <meta property="og:url" content="https://lisker.me/">
+    <meta property="og:image" content="https://lisker.me/images/avatar-compressed.jpg">
+    <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@type": "WebSite",
+          "name": "Paul Lisker",
+          "alternateName": "Paul Lisker | Software Engineer & Privacy Researcher",
+          "url": "https://lisker.me/"
+        }
+      </script>
+    <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@type": "Person",
+          "name": "Paul Lisker",
+          "url": "https://lisker.me/",
+          "jobTitle": "Software Engineer",
+          "alumniOf": {
+            "@type": "CollegeOrUniversity",
+            "name": "Harvard University"
+          },
+          "sameAs": [
+            "https://www.linkedin.com/in/paullisker/",
+            "https://www.instagram.com/paullisker/",
+            "https://letterboxd.com/plisker/",
+            "https://github.com/plisker/"
+          ]
+        }
+      </script>
 </head>
 
 <body class="is-loading">


### PR DESCRIPTION
## Summary

Paired with `plisker/sub_karyn#2`. Google was surfacing "Paul Lisker" as the site name for `karyn.lisker.me` search results, likely because the subdomain inherits apex identity and the apex had almost no explicit site-name signals.

This commit gives `lisker.me` the same five-signal site-name declaration `karyn.lisker.me` just got, so Google can bind "Paul Lisker" firmly to the apex and treat the subdomain's own signals as authoritative for its own name:

- `<meta name="application-name" content="Paul Lisker">`
- Full OG set (`og:type`, `og:site_name`, `og:title`, `og:description`, `og:url`, `og:image`) — previously none were set on this page
- `WebSite` JSON-LD with `name`, `alternateName`, `url`
- `Person` JSON-LD with `jobTitle`, `alumniOf`, and `sameAs` links to LinkedIn / Instagram / Letterboxd / GitHub

No visible changes — only `<head>` metadata.

## Test plan
- [ ] Page renders unchanged (verified locally)
- [ ] Merge, wait for Pages deploy, then paste `https://lisker.me/` into https://search.google.com/test/rich-results and confirm WebSite + Person schema are detected
- [ ] Request reindex in Search Console for `https://lisker.me/`