### PR TITLE
Add Google Scholar profile to Person sameAs

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,8 @@ Free for personal and commercial use under the CCA 3.0 license (html5up.net/lice
             "https://www.linkedin.com/in/paullisker/",
             "https://www.instagram.com/paullisker/",
             "https://letterboxd.com/plisker/",
-            "https://github.com/plisker/"
+            "https://github.com/plisker/",
+            "https://scholar.google.com/citations?user=TRufNXcAAAAJ"
           ]
         }
       </script>


### PR DESCRIPTION
Add Paul's Google Scholar citation profile (`?user=TRufNXcAAAAJ`) to the Person JSON-LD `sameAs` array. Scholar is a strong Knowledge Graph signal for authors and researchers — directly indexed by Google and authoritative about publication identity.

URL stripped of language hint (`hl=en`) and tracking param (`oi=ao`) to the canonical minimal form, matching the `?si=...` cleanup done on Zev Kane's Spotify URLs.

Single one-line addition to the Person JSON-LD block in the homepage head. No visible DOM impact. JSON-LD validated via `json.loads`.