### PR TITLE
Add robots.txt allowing all crawlers and referencing sitemap

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow:
+
+Sitemap: https://lisker.me/sitemap.xml


### PR DESCRIPTION
## Summary

Add a root-level `robots.txt` for `lisker.me`. It allows all crawlers and points to the host's sitemap with an absolute URL:

```
User-agent: *
Disallow:

Sitemap: https://lisker.me/sitemap.xml
```

Confirmed `sitemap.xml` is accurate before referencing it — it already covers the current top-level pages (`/`, `lisker_resume.pdf`, `privacy_policy.html`, `cookie_policy.html`) with absolute `https://lisker.me/...` URLs and no subdomain entries, so no sitemap changes were needed. Subdomains (`photos.`, `projects.`, `music.`) have their own per-host robots/sitemap and are intentionally excluded.

Both files are plain files at the repo root, so GitHub Pages serves them from the site root.

## Test plan

- [ ] After merge, verify `https://lisker.me/robots.txt` resolves and references the sitemap
- [ ] Verify `https://lisker.me/sitemap.xml` resolves